### PR TITLE
Added super linter to the base workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -52,17 +52,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_CSHARP: true
   build:
     name: Build on windows-latest
     runs-on: windows-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -50,7 +50,7 @@ env:
 
 jobs:
   lint:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,9 +21,6 @@ on:
       env_var_name_6:
         required: false
         type: string
-      lint_ignore:
-        required: false
-        type: string
       workdir:
         required: false
         type: string
@@ -63,7 +60,6 @@ jobs:
           DEFAULT_BRANCH: main
           OUTPUT_DETAILS: detailed
           VALIDATE_CSHARP: true
-          VALIDATE_GITLEAKS: true
           IGNORE_GITIGNORED_FILES: true
           FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,7 +21,7 @@ on:
       env_var_name_6:
         required: false
         type: string
-      lint_ingnore:
+      lint_ignore:
         required: false
         type: string
       workdir:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -49,9 +49,25 @@ env:
   azure_artifacts_feed_url: https://pkgs.dev.azure.com/frends-platform/frends-tasks/_packaging/test/nuget/v3/index.json
 
 jobs:
+  lint:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        working-directory: "${{ env.workdir }}"
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_CSHARP: true
   build:
     name: Build on windows-latest
     runs-on: windows-latest
+    needs: lint
     
     steps:
     - uses: actions/checkout@v1
@@ -146,7 +162,7 @@ jobs:
       with:
         script: |
             core.setFailed('Coverage test below tolerance')
-      
+
     - name: Pack release version of task
       run: dotnet pack --configuration Release --include-source
       working-directory: "${{ env.workdir }}"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -57,6 +57,10 @@ jobs:
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: main
+          OUTPUT_DETAILS: detailed
+          VALIDATE_CSHARP: true
+          
   build:
     name: Build on windows-latest
     runs-on: windows-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,7 +62,7 @@ jobs:
           VALIDATE_CSHARP: true
           VALIDATE_GITLEAKS: true
           IGNORE_GITIGNORED_FILES: true
-          DEFAULT_WORKSPACE: "${{ inputs.workdir }}"
+          FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
 
   build:
     name: Build on windows-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -52,14 +52,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Lint Code Base
+      - uses: actions/checkout@v1
+        name: Lint Code Base
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build:
     name: Build on windows-latest
     runs-on: windows-latest
-    needs: lint
     
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_CSHARP: true

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-        name: Lint Code Base
+      - name: Lint Code Base
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,6 +21,9 @@ on:
       env_var_name_6:
         required: false
         type: string
+      lint_ingnore:
+        required: false
+        type: string
       workdir:
         required: false
         type: string

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -60,7 +60,10 @@ jobs:
           DEFAULT_BRANCH: main
           OUTPUT_DETAILS: detailed
           VALIDATE_CSHARP: true
-          
+          VALIDATE_GITLEAKS: true
+          IGNORE_GITIGNORED_FILES: true
+          DEFAULT_WORKSPACE: "${{ env.workdir }}"
+
   build:
     name: Build on windows-latest
     runs-on: windows-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -58,7 +58,6 @@ jobs:
           fetch-depth: 0
       - name: Lint Code Base
         uses: github/super-linter@v4
-        working-directory: "${{ env.workdir }}"
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,7 +62,7 @@ jobs:
           VALIDATE_CSHARP: true
           VALIDATE_GITLEAKS: true
           IGNORE_GITIGNORED_FILES: true
-          DEFAULT_WORKSPACE: "${{ env.workdir }}"
+          DEFAULT_WORKSPACE: "${{ inputs.workdir }}"
 
   build:
     name: Build on windows-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -49,7 +49,7 @@ env:
   azure_artifacts_feed_url: https://pkgs.dev.azure.com/frends-platform/frends-tasks/_packaging/test/nuget/v3/index.json
 
 jobs:
-  lint:
+  Code Quality Check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -52,7 +52,7 @@ jobs:
           VALIDATE_CSHARP: true
           VALIDATE_GITLEAKS: true
           IGNORE_GITIGNORED_FILES: true
-          DEFAULT_WORKSPACE: "${{ inputs.workdir }}"
+          FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
 
   build:
     name: Build on ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -24,7 +24,7 @@ on:
       workdir:
         required: false
         type: string
-      lint_ingnore:
+      lint_ignore:
         required: false
         type: string
       prebuild_command:

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -39,6 +39,15 @@ env:
   azure_artifacts_feed_url: https://pkgs.dev.azure.com/frends-platform/frends-tasks/_packaging/test/nuget/v3/index.json
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
   build:
     name: Build on ubuntu-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -49,7 +49,7 @@ env:
   azure_artifacts_feed_url: https://pkgs.dev.azure.com/frends-platform/frends-tasks/_packaging/test/nuget/v3/index.json
 
 jobs:
-  lint:
+  Code Quality Check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -24,9 +24,6 @@ on:
       workdir:
         required: false
         type: string
-      lint_ignore:
-        required: false
-        type: string
       prebuild_command:
         required: false
         type: string
@@ -64,10 +61,8 @@ jobs:
         DEFAULT_BRANCH: main
         OUTPUT_DETAILS: detailed
         VALIDATE_CSHARP: true
-        VALIDATE_GITLEAKS: true
         IGNORE_GITIGNORED_FILES: true
         FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
-        FILTER_REGEX_EXCLUDE: "${{ inputs.lint_ignore}}"
 
   build:
     name: Build on ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -47,7 +47,10 @@ jobs:
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+          DEFAULT_BRANCH: main
+          OUTPUT_DETAILS: detailed
+          VALIDATE_CSHARP: true
+
   build:
     name: Build on ubuntu-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -50,6 +50,9 @@ jobs:
           DEFAULT_BRANCH: main
           OUTPUT_DETAILS: detailed
           VALIDATE_CSHARP: true
+          VALIDATE_GITLEAKS: true
+          IGNORE_GITIGNORED_FILES: true
+          DEFAULT_WORKSPACE: "${{ env.workdir }}"
 
   build:
     name: Build on ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -15,7 +15,16 @@ on:
       env_var_name_4:
         required: false
         type: string
+      env_var_name_5:
+        required: false
+        type: string
+      env_var_name_6:
+        required: false
+        type: string
       workdir:
+        required: false
+        type: string
+      lint_ingnore:
         required: false
         type: string
       prebuild_command:
@@ -30,6 +39,10 @@ on:
         required: false
       env_var_value_4:
         required: false
+      env_var_value_5:
+        required: false
+      env_var_value_6:
+        required: false
       badge_service_api_key:
         required: true
       test_feed_api_key:
@@ -42,17 +55,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Lint Code Base
-        uses: github/super-linter@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BRANCH: main
-          OUTPUT_DETAILS: detailed
-          VALIDATE_CSHARP: true
-          VALIDATE_GITLEAKS: true
-          IGNORE_GITIGNORED_FILES: true
-          FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
+    - uses: actions/checkout@v1
+    
+    - name: Lint Code Base
+      uses: github/super-linter@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BRANCH: main
+        OUTPUT_DETAILS: detailed
+        VALIDATE_CSHARP: true
+        VALIDATE_GITLEAKS: true
+        IGNORE_GITIGNORED_FILES: true
+        FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
+        FILTER_REGEX_EXCLUDE: "${{ input.lint_ignore}}"
 
   build:
     name: Build on ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -52,7 +52,7 @@ jobs:
           VALIDATE_CSHARP: true
           VALIDATE_GITLEAKS: true
           IGNORE_GITIGNORED_FILES: true
-          DEFAULT_WORKSPACE: "${{ env.workdir }}"
+          DEFAULT_WORKSPACE: "${{ inputs.workdir }}"
 
   build:
     name: Build on ubuntu-latest

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -67,7 +67,7 @@ jobs:
         VALIDATE_GITLEAKS: true
         IGNORE_GITIGNORED_FILES: true
         FILTER_REGEX_INCLUDE: "${{ inputs.workdir }}"
-        FILTER_REGEX_EXCLUDE: "${{ input.lint_ignore}}"
+        FILTER_REGEX_EXCLUDE: "${{ inputs.lint_ignore}}"
 
   build:
     name: Build on ubuntu-latest


### PR DESCRIPTION
#38 
Added super linter to lint all code in the working directory.
Note that if workdir is not given the super linter will lint all repository.
Linting is done only when pushing but can be implemented to merging as well.