### PR TITLE
Add alias for docker-compose to linux_build_main

### DIFF
--- a/.github/workflows/linux_build_main.yml
+++ b/.github/workflows/linux_build_main.yml
@@ -64,6 +64,13 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+
+    # An alias is needed so that docker-compose works with the dash in between.
+    - name: Create alias for docker-compose
+      run: |
+        sudo touch /usr/bin/docker-compose
+        sudo echo 'docker compose --compatibility "$@"' | sudo tee /usr/bin/docker-compose
+        sudo chmod +x /usr/bin/docker-compose
     
     ###############################
     # SETUP DOTNET                #

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -89,6 +89,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
+    # An alias is needed so that docker-compose works with the dash in between.
     - name: Create alias for docker-compose
       run: |
         sudo touch /usr/bin/docker-compose


### PR DESCRIPTION
closes #78

Simply put, since the Action runs on ubuntu-latest, we need an alias so that docker-compose works (on linux the command is without the dash by standard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflow by adding steps to create an alias for the `docker-compose` command, ensuring compatibility with existing scripts.
	- Improved reliability of the Linux build and test workflow by addressing potential command recognition issues with `docker-compose`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->