### PR TITLE
Set Ubuntu 22.04 as the used OS version for linux main build

### DIFF
--- a/.github/workflows/linux_build_main.yml
+++ b/.github/workflows/linux_build_main.yml
@@ -59,8 +59,8 @@ on:
 
 jobs:
   build:
-    name: Build main branch
-    runs-on: ubuntu-latest
+    name: Build on ubuntu-22.04
+    runs-on: ubuntu-22.04
     
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new workflow inputs: `workdir` and `prebuild_command`.
	- Introduced a new workflow secret: `badge_service_api_key`.
  
- **Updates**
	- Updated job name from "Build main branch" to "Build on ubuntu-22.04".
	- Changed job runner from `ubuntu-latest` to `ubuntu-22.04`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->